### PR TITLE
always notify if not correctly setup

### DIFF
--- a/src/preprocessor/noop.js
+++ b/src/preprocessor/noop.js
@@ -3,7 +3,7 @@
  * this preprocessor is setup by our recommended rules for gjs/gts, so it will always be called for it
  * the flow is the following:
  *  1. gjs/gts files goes through our parses, which calls registerParsedFile, if its not correctly setup, registerParsedFile will not be called
- *  2. postprocess checks if the file is registered and if not throws an error (only if parsing failed)
+ *  2. postprocess checks if the file is registered and if not throws an error
  *
  */
 
@@ -16,16 +16,13 @@ module.exports = {
   preprocess: null,
   postprocess: (messages, fileName) => {
     const msgs = messages.flat();
-    if (
-      msgs.length === 1 &&
-      msgs[0].ruleId === null &&
-      msgs[0].message.startsWith('Parsing error: ')
-    ) {
-      if (!parsedFiles.has(fileName)) {
-        msgs[0].message += '\n';
-        msgs[0].message +=
-          'To lint Gjs/Gts files please follow the setup guide at https://github.com/ember-cli/eslint-plugin-ember#gtsgjs';
-      }
+    if (!parsedFiles.has(fileName)) {
+      msgs[0] = msgs[0] || {
+        message: '',
+      };
+      msgs[0].message += '\n';
+      msgs[0].message += 
+        'To lint Gjs/Gts files please follow the setup guide at https://github.com/ember-cli/eslint-plugin-ember#gtsgjs';
     }
     parsedFiles.delete(fileName); // required for tests
     return msgs;


### PR DESCRIPTION
There can be different kind of errors depending on which parser was setup instead of ours.
Just notify the user whenever he uses gjs/gts without our parser 