### PR TITLE
no-undef: custome elements are not defined

### DIFF
--- a/test-projects/gts/src/custom-elements.gts
+++ b/test-projects/gts/src/custom-elements.gts
@@ -1,0 +1,5 @@
+
+<template>
+  <out>short used in tests</out>
+  <defined-elsewhere>web component</defined-elsewhere>
+</template>


### PR DESCRIPTION
After some thought, I don't think this is a bug, but we should add some documentation.


----------

Including -- web components -- things defined in global scope that are available, but not in local/file scope.

I'm not sure what we should do about this one.

Maybe the parser needs an option to ignore unknown elements entirely?
Adding to an allowlist would be way too troublesome if anyone is using a web-component library

I'm not sure that this is a bug as the error is reported by `no-undef`, and anything in global scope would have the same issue.

This is, ultimately, one of the fundamental problems I have with the globals-approach to web-components.

Since I only have this issue in a few files, I'm going to use:
```js
/* global <my-var> */
```

per the docs here: https://eslint.org/docs/latest/rules/no-undef


In another project of mine, I've just set the globals key:
```js
    {
      files: ['**/*.{gjs,gts}'],
      plugins: ['ember'],
      parser: 'ember-eslint-parser',
      globals: {
        // used in testing as a shorthand for <output>
        out: true,
      },
    },
```
the globals list will likely (and necessarily) be large for web-component users.